### PR TITLE
Minor typo in GitHub URLs

### DIFF
--- a/protected/application/plugins/github/models/GithubModel.php
+++ b/protected/application/plugins/github/models/GithubModel.php
@@ -62,7 +62,7 @@ class GithubModel extends SourceModel {
 	}
 
 	public function updateData() {
-		$url	= 'https//github.com/' . $this->getProperty('username') . '.atom';
+		$url	= 'https://github.com/' . $this->getProperty('username') . '.atom';
 
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_URL, $url);


### PR DESCRIPTION
Found a minor typo in the http -> https URL switch for GitHub

https://github.com/lmorchard/core/commit/90d0614e728a2a067db6cfb34124fda2c215ce6e
