### PR TITLE
remove superfluous "," in .sql file

### DIFF
--- a/protected/install/database/update/003/add_mentions_table.sql
+++ b/protected/install/database/update/003/add_mentions_table.sql
@@ -15,6 +15,6 @@ CREATE TABLE `mentions` (
   `timestamp` datetime NOT NULL,
   `type` varchar(128) default NULL,
   PRIMARY KEY  (`id`),
-  UNIQUE KEY `item` USING BTREE (`source_id`, `item_id`, `url`),
+  UNIQUE KEY `item` USING BTREE (`source_id`, `item_id`, `url`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 


### PR DESCRIPTION
this was necessary for me to get it to install with MySQL 5.1 on Debian
