### PR TITLE
FIX setcookie when a custom http port is used

### DIFF
--- a/protected/library/Stuffpress/Cookie.php
+++ b/protected/library/Stuffpress/Cookie.php
@@ -46,7 +46,7 @@ class Stuffpress_Cookie {
 	public function set($remember=false) {
 		// Attempt to fetch the path and host from the config
 		$config = Zend_Registry::get("configuration");
-		$host	= $config->web->host;
+		$host	= $this->_gethost($config->web->host);
 		$expire = $remember ? time()+60*60*24*15 : 0;
 		
 		// Send the cookie
@@ -57,7 +57,7 @@ class Stuffpress_Cookie {
 	public function logout() {
 		//	Attempt to fetch the path and host from the config
 		$config = Zend_Registry::get("configuration");
-		$host	= $config->web->host;
+		$host	= $this->_gethost($config->web->host);
 		$path	= $config->web->path;
 		setcookie($this->cookiename, null, 0, "/", ".$host");
 	}
@@ -116,5 +116,10 @@ class Stuffpress_Cookie {
 	
 	private function _reissue() {
 		$this->created = time();
+	}
+
+	private function _gethost($str) {
+		$parsedurl = parse_url($str);
+		return isset($parsedurl['host']) && isset($parsedurl['port']) ? $parsedurl['host'] : $str;
 	}
 }


### PR DESCRIPTION
# Use case without this patch:
- Install Storytlr from http://storytlr.loc:8080/
- Try to login with the same url
- No error displayed
  => It's not possible to set a cookie with a port number in the cookie domain
# Patch:
- Use parse_url PHP function
- Check if there is a custom http port
- if true: just get the host and let the port behind
- if false: return the initial string
